### PR TITLE
Added Dockerfile and docker maven targets

### DIFF
--- a/apolloServer/Dockerfile
+++ b/apolloServer/Dockerfile
@@ -1,0 +1,7 @@
+FROM docker.conygre.com:5000/centos
+MAINTAINER Ketan Reddy <ketan.reddy@citi.com>
+
+ENTRYPOINT ["/usr/bin/java", "-jar", "/usr/share/apollo/server.jar"]
+
+# Add the service itself
+ADD target/ApolloServer-1.0-SNAPSHOT.jar /usr/share/apollo/server.jar

--- a/apolloServer/pom.xml
+++ b/apolloServer/pom.xml
@@ -60,6 +60,27 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <version>1.4.3</version>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>push</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <repository>docker.conygre.com:5000/apolloserver</repository>
+                    <tag>${project.version}</tag>
+                    <buildArgs>
+                        <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+                    </buildArgs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This PR closes #10 

- Adds Dockerfile for apolloServer
- Uses spotify's maven plugin to streamline docker builds with maven